### PR TITLE
Fix terrain map

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -306,7 +306,7 @@ function getTerrain(){
           el.css('background-color', '#000')
         }
 
-        if(tile.type === 'swamp'){
+        if(tile.type === 'swamp' && el.css('background-color') != 'rgb(0, 0, 0)'){
           el.css('background-color', '#292b18')
         }
       }

--- a/style.css
+++ b/style.css
@@ -29,7 +29,7 @@
 	background-repeat: no-repeat;
 }
 .grid td:hover {
-	background-color: #444;
+	background-color: #444 !important;
 }
 textarea {
      width: 100%;


### PR DESCRIPTION
Fixes 2 bugs:

 1. Some walls get replaced with swamps because the swamp is under the wall in the terrain map.
 2. The _active tile_ highlight was not working for swamps or walls.